### PR TITLE
Remove the unnecessary <center> tags

### DIFF
--- a/vignettes/RFmerge-RainfallExample-minimal.Rmd
+++ b/vignettes/RFmerge-RainfallExample-minimal.Rmd
@@ -1,11 +1,11 @@
 ---
-title: <center>Tutorial for merging satellite-based precipitation datasets with ground observations using `RFmerge`</center>
+title: Tutorial for merging satellite-based precipitation datasets with ground observations using `RFmerge`
 author: 
 - Oscar M. Baez-Villanueva^[obaezvil@th-koeln.de]
 - Mauricio Zambrano-Bigiarini^[mauricio.zambrano@ufrontera.cl]
 - Juan Diego Giraldo-Osorio
 - Ian McNamara
-date: <center>`r format(Sys.time(), '%d %B %Y')`</center>
+date: "`r format(Sys.time(), '%d %B %Y')`"
 output: 
   pdf_document:
     number_sections: true


### PR DESCRIPTION
The `<center>` tag can cause trouble with Pandoc 3.x. For example, the generated title in LaTeX would be

```tex
\title{\strut \\
Tutorial for merging satellite-based precipitation datasets with ground
observations using \texttt{RFmerge}\\}
```

which will cause the error

```
! LaTeX Error: There's no line here to end.
```

as you can see from https://www.stats.ox.ac.uk/pub/bdr/M1mac/RFmerge.out

Title and date are centered by default, so there is really no need to try to center them using the `<center>` tag.